### PR TITLE
Try KERNEL_PATH first when loading the kernel

### DIFF
--- a/src/io/CliParser.cpp
+++ b/src/io/CliParser.cpp
@@ -223,19 +223,24 @@ CliOptions CliParser::parse(int argc, char** argv ) {
     }
 
     if (opts.kernel_path.empty()) {
-        try {
+        std::string kernelFile = KERNEL_PATH "prmers.cl";
+        if (std::filesystem::exists(kernelFile)) {
+            opts.kernel_path = kernelFile;
+        } else {
             std::string execDir = util::getExecutableDir();
-            std::string kernelFile = execDir + "/prmers.cl";
-            if (!std::filesystem::exists(kernelFile)) {
+            kernelFile = execDir + "/prmers.cl";
+            if (std::filesystem::exists(kernelFile)) {
+                opts.kernel_path = kernelFile;
+            } else {
                 kernelFile = execDir + "/kernels/prmers.cl";
-                if (!std::filesystem::exists(kernelFile)) {
-                    throw std::runtime_error("Kernel file 'prmers.cl' not found");
+                if (std::filesystem::exists(kernelFile)) {
+                    opts.kernel_path = kernelFile;
+                } else {
+                    std::cerr << "Error: Cannot find kernel file 'prmers.cl'"
+                              << std::endl;
+                    std::exit(1);
                 }
             }
-            opts.kernel_path = kernelFile;
-        } catch (const std::exception& e) {
-            std::cerr << "Error locating OpenCL kernel: " << e.what() << "\n";
-            std::exit(1);
         }
     }
     unsigned int detectedPort = 0;


### PR DESCRIPTION
`KERNEL_PATH` is passed to the compiler, so apparently it's meant to be used. But it's not used. This PR makes `prmers` try `KERNEL_PATH` before the locations relative to the executable.

The relative locations won't work even for the default installation, when `prmers` goes to `/usr/local/bin` and `prmers.cl` goes to `/usr/local/share/prmers`. `/usr/local/bin/prmers` would look for `/usr/local/bin/prmers.cl` and `/usr/local/bin/kernels/prmers.cl`, and both would be unsuccessful.

I removed some intermediate error messages and exception handling, as the logic gets quite complex with 3 candidate locations.