### PR TITLE
Initialize twiddle5 buffers with `nullptr`

### DIFF
--- a/src/opencl/Buffers.cpp
+++ b/src/opencl/Buffers.cpp
@@ -27,7 +27,7 @@
 namespace opencl {
 
 Buffers::Buffers(const opencl::Context& ctx, const math::Precompute& pre)
-  : input(nullptr)
+  : input(nullptr), twiddle5Buf(nullptr), invTwiddle5Buf(nullptr)
 {
     const size_t n = pre.getN();
     const size_t twiddle4Size = (n % 5 == 0) ? 3 * n / 5 : 3 * n;


### PR DESCRIPTION
Commit 2a6b456 almost fixes segmentation fault on my system: now I can successfully run a test of M30402457 with PrMers. But I get a segfault after I interrupt an execution:

```bash
Initial x[0] set to 3 (PRP mode)
Progress: 0.00% | Exp: 30402457 | Iter: 0 | Elapsed: 0.00s | IPS: 0.00 | ETA: 0d 0h 0m 0s
Progress: 0.04% | Exp: 30402457 | Iter: 13000 | Elapsed: 10.10s | IPS: 1286.55 | ETA: 0d 6h 33m 40s
Progress: 0.09% | Exp: 30402457 | Iter: 26000 | Elapsed: 20.15s | IPS: 1294.73 | ETA: 0d 6h 33m 23s
Progress: 0.13% | Exp: 30402457 | Iter: 39500 | Elapsed: 30.44s | IPS: 1310.78 | ETA: 0d 6h 32m 50s
Progress: 0.17% | Exp: 30402457 | Iter: 53000 | Elapsed: 40.74s | IPS: 1311.08 | ETA: 0d 6h 32m 19s
^C
Interrupted signal received
 

State saved to ./30402457prp.mers
Loop iteration saved to ./30402457prp.loop

Interrupted by user, state saved at iteration 57499
Segmentation fault (core dumped)
```

Right now `twiddle5Buf` and `invTwiddle5Buf` are only initialized conditionally in the constructor:

```cpp
if (n%5==0) {
    twiddle5Buf = createBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
        twiddle5Size * sizeof(uint64_t),
        pre.twiddlesRadix5().data(), "twiddles5");

    invTwiddle5Buf = createBuffer(ctx, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
        twiddle5Size * sizeof(uint64_t),
        pre.invTwiddlesRadix5().data(), "invTwiddles5");
 }
```

But are always freed in the destructor, even though it checks if they are not null:

```cpp
Buffers::~Buffers() {
    ...
    if (twiddle5Buf)         clReleaseMemObject(twiddle5Buf);
    if (invTwiddle5Buf)      clReleaseMemObject(invTwiddle5Buf);
    ...
}
```

However, if those buffers are unitialized, this might result in an attempt to free some random memory, and thus cause a segfault. To fix this I propose to always initialize those buffers to `nullptr` in the constructor. I tested it and it indeed fixes the problem on my system.