### PR TITLE
Add proof file generation to PrMers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ else
   LDFLAGS  += -lOpenCL
 endif
 
+# GMP library
+LDFLAGS += -lgmp
+
 # Curl (optionnel)
 USE_CURL ?= 1
 ifeq ($(USE_CURL),1)

--- a/include/core/Proof.hpp
+++ b/include/core/Proof.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include <filesystem>
+
+namespace core {
+
+class Proof {
+public:
+    const uint32_t E;
+    const std::vector<uint32_t> B;
+    const std::vector<std::vector<uint32_t>> middles;
+
+    Proof(uint32_t exponent, std::vector<uint32_t> finalResidue, std::vector<std::vector<uint32_t>> intermediateResidues)
+        : E(exponent), B(std::move(finalResidue)), middles(std::move(intermediateResidues)) {}
+
+    // File I/O methods for proof files
+    void save(const std::filesystem::path& filePath) const;
+    static Proof load(const std::filesystem::path& filePath);
+    
+    // Hash functions for proof generation
+    static std::array<uint64_t, 4> hashWords(uint32_t E, const std::vector<uint32_t>& words);
+    static std::array<uint64_t, 4> hashWords(uint32_t E, 
+                                           const std::array<uint64_t, 4>& hash,
+                                           const std::vector<uint32_t>& words);
+    static uint64_t res64(const std::vector<uint32_t>& words);
+};
+
+} // namespace core

--- a/include/core/ProofManager.hpp
+++ b/include/core/ProofManager.hpp
@@ -10,6 +10,7 @@
 # include <CL/cl.h>
 #endif
 #include <cstdint>
+#include <filesystem>
 #include "core/ProofSet.hpp"
 
 namespace core {
@@ -17,14 +18,17 @@ namespace core {
 class ProofManager {
 public:
     ProofManager(uint32_t exponent, int proofLevel,
-                 cl_command_queue queue, uint32_t n);
-    void checkpoint(cl_mem buf, uint32_t iter);
+                 cl_command_queue queue, uint32_t n,
+                 const std::vector<int>& digitWidth);
+    void checkpoint(cl_mem buf, uint32_t iter);    
+    std::filesystem::path proof() const;
 
 private:
     ProofSet           proofSet_;
     cl_command_queue   queue_;
     uint32_t           n_;
     uint32_t           exponent_;
+    std::vector<int>   digitWidth_;
 };
 
 }

--- a/include/core/ProofSet.hpp
+++ b/include/core/ProofSet.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "core/Proof.hpp"
 #include <cstdint>
 #include <vector>
+#include <filesystem>
+#include <gmpxx.h>
 
 namespace core {
 
@@ -11,6 +14,7 @@ public:
     explicit Words(const std::vector<uint64_t>& v);
 
     const std::vector<uint64_t>& data() const noexcept;
+    std::vector<uint64_t>& data() noexcept;
 
     static Words fromUint64(const std::vector<uint64_t>& host, uint32_t exponent);
 
@@ -20,12 +24,35 @@ private:
 
 class ProofSet {
 public:
-    ProofSet(uint32_t exponent, int proofLevel);
+    const uint32_t E;     // exponent
+    const uint32_t power; // proof power level
+
+    ProofSet(uint32_t exponent, uint32_t proofLevel);
 
     bool shouldCheckpoint(uint32_t iter) const;
-    void save(uint32_t iter, const Words& words);
+    void save(uint32_t iter, const std::vector<uint32_t>& words);
+    std::vector<uint32_t> load(uint32_t iter) const;
 
     static Words fromUint64(const std::vector<uint64_t>& host, uint32_t exponent);
+    static uint32_t bestPower(uint32_t E);
+    static bool isInPoints(uint32_t E, uint32_t power, uint32_t k);
+    static std::filesystem::path proofPath(uint32_t E);
+    static double diskUsageGB(uint32_t E, uint32_t power);
+    
+    // Core proof generation algorithm
+    Proof computeProof() const;
+
+private:
+    std::vector<uint32_t> points; // checkpoint iteration points
+    
+    bool isValidTo(uint32_t limitK) const;
+    bool fileExists(uint32_t k) const;
+    
+    // GMP-based modular arithmetic helpers
+    mpz_class convertToGMP(const std::vector<uint32_t>& words) const;
+    std::vector<uint32_t> convertFromGMP(const mpz_class& gmp_val) const;
+    mpz_class mersenneReduce(const mpz_class& x, uint32_t E) const;
+    mpz_class mersennePowMod(const mpz_class& base, uint64_t exp, uint32_t E) const;
 };
 
 } // namespace core

--- a/include/io/JsonBuilder.hpp
+++ b/include/io/JsonBuilder.hpp
@@ -47,6 +47,11 @@ public:
          const std::vector<int>& digit_width,
          double /*elapsed*/,
          int /*transform_size*/);
+
+    static std::vector<uint32_t> compactBits(
+        const std::vector<uint64_t>& x,
+        const std::vector<int>& digit_width,
+        uint32_t E);
 };
 
 } // namespace io

--- a/include/io/Sha3Hash.h
+++ b/include/io/Sha3Hash.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "io/sha3.h"
+#include "io/Hash.h"
 
 #include <vector>
 #include <array>
@@ -52,6 +53,5 @@ public:
   }
 };
 
-#include "io/Hash.h"
 using SHA3 = Hash<Sha3Hash>;
 } // namespace io

--- a/include/util/Crc32.hpp
+++ b/include/util/Crc32.hpp
@@ -1,6 +1,9 @@
 #ifndef CRC32_HPP
 #define CRC32_HPP
 #include <string>
-unsigned int computeCRC32(const std::string &data);
+#include <cstdint>
+#include <cstddef>
+uint32_t computeCRC32(const std::string &data);
+uint32_t computeCRC32(const void* data, size_t size);
 std::string toLower(const std::string &s);
 #endif

--- a/src/core/Proof.cpp
+++ b/src/core/Proof.cpp
@@ -1,0 +1,203 @@
+/*
+ * Mersenne OpenCL Primality Test Host Code
+ *
+ * This code is inspired by:
+ *   - "mersenne.cpp" by Yves Gallot (Copyright 2020, Yves Gallot) based on
+ *     Nick Craig-Wood's IOCCC 2012 entry (https://github.com/ncw/ioccc2012).
+ *   - The Armprime project, explained at:
+ *         https://www.craig-wood.com/nick/armprime/
+ *     and available on GitHub at:
+ *         https://github.com/ncw/
+ *   - Yves Gallot (https://github.com/galloty), author of Genefer 
+ *     (https://github.com/galloty/genefer22), who helped clarify the NTT and IDBWT concepts.
+ *   - The GPUOwl project (https://github.com/preda/gpuowl), which performs Mersenne
+ *     searches using FFT and double-precision arithmetic.
+ * This code performs a Mersenne prime search using integer arithmetic and an IDBWT via an NTT,
+ * executed on the GPU through OpenCL.
+ *
+ * Author: Cherubrock
+ *
+ * This code is released as free software. 
+ */
+#include "core/Proof.hpp"
+#include "io/Sha3Hash.h"
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace core {
+
+// Proof file I/O implementations
+void Proof::save(const std::filesystem::path& filePath) const {
+  std::ofstream file(filePath, std::ios::binary);
+  if (!file) {
+    throw std::runtime_error("Cannot create proof file: " + filePath.string());
+  }
+
+  // Write ASCII header according to GIMPS specification
+  file << "PRP PROOF\n";
+  file << "VERSION=2\n";
+  file << "HASHSIZE=64\n";
+  file << "POWER=" << middles.size() << "\n";
+  file << "NUMBER=M" << E << "\n";
+
+  if (!file.good()) {
+    throw std::runtime_error("Error writing proof file header: " + filePath.string());
+  }
+
+  // Helper function to write a residue
+  auto writeResidue = [&](const std::vector<uint32_t>& residue) {
+    uint32_t nBytes = (E - 1) / 8 + 1;
+    
+    // Write the residue data as bytes in little-endian format
+    for (uint32_t byteIdx = 0; byteIdx < nBytes; ++byteIdx) {
+      uint32_t wordIdx = byteIdx / 4;
+      uint32_t byteInWord = byteIdx % 4;
+      
+      uint8_t byte = 0;
+      if (wordIdx < residue.size()) {
+        byte = static_cast<uint8_t>((residue[wordIdx] >> (byteInWord * 8)) & 0xFF);
+      }
+      file.write(reinterpret_cast<const char*>(&byte), 1);
+    }
+  };
+
+  // Write final residue B first
+  writeResidue(B);
+
+  // Write all intermediate residues (middles)
+  for (const auto& middle : middles) {
+    writeResidue(middle);
+  }
+
+  if (!file.good()) {
+    throw std::runtime_error("Error writing proof file data: " + filePath.string());
+  }
+}
+
+Proof Proof::load(const std::filesystem::path& filePath) {
+  std::ifstream file(filePath, std::ios::binary);
+  if (!file) {
+    throw std::runtime_error("Cannot open proof file: " + filePath.string());
+  }
+
+  // Parse ASCII header
+  std::string line;
+  uint32_t version = 0, hashsize = 0, power = 0, exponent = 0;
+
+  // Read and validate "PRP PROOF"
+  if (!std::getline(file, line) || line != "PRP PROOF") {
+    throw std::runtime_error("Invalid proof file header: " + filePath.string());
+  }
+
+  // Parse header fields (VERSION, HASHSIZE, POWER, NUMBER)
+  // Binary data starts after NUMBER
+  for (int i = 0; i < 4; ++i) {
+    if (!std::getline(file, line)) {
+      throw std::runtime_error("Incomplete header in proof file: " + filePath.string());
+    }
+    
+    size_t eq_pos = line.find('=');
+    if (eq_pos == std::string::npos) {
+      throw std::runtime_error("Malformed header line in proof file: " + line);
+    }
+    
+    std::string key = line.substr(0, eq_pos);
+    std::string value = line.substr(eq_pos + 1);
+    
+    if (key == "VERSION") {
+      version = std::stoul(value);
+    } else if (key == "HASHSIZE") {
+      hashsize = std::stoul(value);
+    } else if (key == "POWER") {
+      power = std::stoul(value);
+    } else if (key == "NUMBER" && !value.empty() && value[0] == 'M') {
+      exponent = std::stoul(value.substr(1));
+    } else {
+      throw std::runtime_error("Unexpected header field: " + key);
+    }
+  }
+
+  // Validate header values
+  if (version != 2) {
+    throw std::runtime_error("Unsupported proof file version: " + std::to_string(version));
+  }
+  if (hashsize != 64) {
+    throw std::runtime_error("Unsupported hash size: " + std::to_string(hashsize));
+  }
+  if (power == 0 || power > 12) {
+    throw std::runtime_error("Invalid proof power: " + std::to_string(power));
+  }
+  if (exponent == 0) {
+    throw std::runtime_error("Invalid or missing exponent in proof file");
+  }
+
+  // Helper function to read a residue
+  auto readResidue = [&]() -> std::vector<uint32_t> {
+    uint32_t nBytes = (exponent - 1) / 8 + 1;
+    uint32_t nWords = (exponent + 31) / 32;
+    std::vector<uint32_t> data(nWords, 0);
+    
+    for (uint32_t byteIdx = 0; byteIdx < nBytes; ++byteIdx) {
+      uint8_t byte;
+      file.read(reinterpret_cast<char*>(&byte), 1);
+      if (!file.good()) {
+        throw std::runtime_error("Error reading residue data from proof file");
+      }
+      
+      uint32_t wordIdx = byteIdx / 4;
+      uint32_t byteInWord = byteIdx % 4;
+      
+      if (wordIdx < nWords) {
+        data[wordIdx] |= (static_cast<uint32_t>(byte) << (byteInWord * 8));
+      }
+    }
+    
+    return data;
+  };
+
+  // Read final residue B
+  auto B = readResidue();
+
+  // Read intermediate residues (middles)
+  std::vector<std::vector<uint32_t>> middles;
+  for (uint32_t i = 0; i < power; ++i) {
+    middles.push_back(readResidue());
+  }
+
+  return Proof(exponent, std::move(B), std::move(middles));
+}
+
+// Hash functions for proof generation
+std::array<uint64_t, 4> Proof::hashWords(uint32_t E, const std::vector<uint32_t>& words) {
+  // Hash the words data
+  io::SHA3 hasher;
+  uint32_t nBytes = (E - 1) / 8 + 1;
+  return std::move(hasher.update(words.data(), nBytes)).finish();
+}
+
+std::array<uint64_t, 4> Proof::hashWords(uint32_t E, 
+                                         const std::array<uint64_t, 4>& prefix,
+                                         const std::vector<uint32_t>& words) {
+  // Hash the prefix first, then the words data
+  io::SHA3 hasher;
+  uint32_t nBytes = (E - 1) / 8 + 1;
+  hasher.update(prefix.data(), prefix.size() * sizeof(uint64_t));
+  return std::move(hasher.update(words.data(), nBytes)).finish();
+}
+
+uint64_t Proof::res64(const std::vector<uint32_t>& words) {
+  // Extract lower 64 bits from 32-bit words
+  // Combines words[1] << 32 | words[0]
+  if (words.empty()) return 0;
+  
+  uint64_t result = words[0];
+  if (words.size() > 1) {
+    result |= (static_cast<uint64_t>(words[1]) << 32);
+  }
+  return result;
+}
+
+} // namespace core

--- a/src/core/ProofSet.cpp
+++ b/src/core/ProofSet.cpp
@@ -20,6 +20,15 @@
  * This code is released as free software. 
  */
 #include "core/ProofSet.hpp"
+#include "io/Sha3Hash.h"
+#include "util/Crc32.hpp"
+#include "util/Timer.hpp"
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <iomanip>
 
 namespace core {
 
@@ -33,29 +42,366 @@ const std::vector<uint64_t>& Words::data() const noexcept {
     return data_;
 }
 
+std::vector<uint64_t>& Words::data() noexcept {
+    return data_;
+}
+
 Words Words::fromUint64(const std::vector<uint64_t>& host, uint32_t exponent) {
     (void)exponent;
     return Words(host);
 }
 
 // ProofSet
-ProofSet::ProofSet(uint32_t exponent, int proofLevel) {
-    (void)exponent;
-    (void)proofLevel;
+ProofSet::ProofSet(uint32_t exponent, uint32_t proofLevel)
+  : E{exponent}, power{proofLevel} {
+  
+  assert(E & 1); // E is supposed to be prime
+  if (power <= 0 || power > 12) {
+    throw std::runtime_error("Invalid proof power: " + std::to_string(power));
+  }
+
+  // Create proof directory
+  std::filesystem::create_directories(proofPath(E));
+
+  // Calculate checkpoint points using binary tree structure
+  std::vector<uint32_t> spans;
+  for (uint32_t span = (E + 1) / 2; spans.size() < power; span = (span + 1) / 2) { 
+    spans.push_back(span); 
+  }
+
+  points.push_back(0);
+  for (uint32_t p = 0, span = (E + 1) / 2; p < power; ++p, span = (span + 1) / 2) {
+    for (uint32_t i = 0, end = points.size(); i < end; ++i) {
+      points.push_back(points[i] + span);
+    }
+  }
+
+  assert(points.size() == (1u << power));
+  assert(points.front() == 0);
+
+  points.front() = E;
+  std::sort(points.begin(), points.end());
+
+  assert(points.size() == (1u << power));
+  assert(points.back() == E);
+
+  points.push_back(uint32_t(-1)); // guard element
+
+  // Verify all points are valid
+  for (uint32_t p : points) {
+    assert(p > E || isInPoints(E, power, p));
+  }
 }
 
 bool ProofSet::shouldCheckpoint(uint32_t iter) const {
-    (void)iter;
-    return false;
+  return isInPoints(E, power, iter);
 }
 
-void ProofSet::save(uint32_t iter, const Words& words) {
-    (void)iter;
-    (void)words;
+void ProofSet::save(uint32_t iter, const std::vector<uint32_t>& words) {
+  if (!shouldCheckpoint(iter)) {
+    return;
+  }
+
+  // Create the file path for this iteration
+  auto filePath = proofPath(E) / std::to_string(iter);
+  
+  // Write the words data to file
+  std::ofstream file(filePath, std::ios::binary);
+  if (!file) {
+    throw std::runtime_error("Cannot create proof checkpoint file: " + filePath.string());
+  }
+  
+  // Write CRC32 first, then the data
+  uint32_t crc = computeCRC32(words.data(), words.size() * sizeof(uint32_t));
+  file.write(reinterpret_cast<const char*>(&crc), sizeof(crc));
+  file.write(reinterpret_cast<const char*>(words.data()), 
+             words.size() * sizeof(uint32_t));
+  
+  if (!file.good()) {
+    throw std::runtime_error("Error writing proof checkpoint file: " + filePath.string());
+  }
 }
 
 Words ProofSet::fromUint64(const std::vector<uint64_t>& host, uint32_t exponent) {
     return Words::fromUint64(host, exponent);
+}
+
+uint32_t ProofSet::bestPower(uint32_t E) {
+  // Best proof powers assuming no disk space concern.
+  // We increment power by 1 for each fourfold increase of the exponent.
+  // The values below produce power=10 at wavefront, and power=11 at 100Mdigits:
+  // power=10 from 60M to 240M, power=11 from 240M up.
+
+  assert(E > 0);
+  // log2(x)/2 is log4(x)
+  int power = 10 + std::floor(std::log2(E / 60e6) / 2);
+  assert(power >= 2);
+  return static_cast<uint32_t>(power);
+}
+
+bool ProofSet::isInPoints(uint32_t E, uint32_t power, uint32_t k) {
+  if (k == E) { return true; } // special-case E
+  uint32_t start = 0;
+  for (uint32_t p = 0, span = (E + 1) / 2; p < power; ++p, span = (span + 1) / 2) {
+    assert(k >= start);
+    if (k > start + span) {
+      start += span;
+    } else if (k == start + span) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::filesystem::path ProofSet::proofPath(uint32_t E) {
+  return std::filesystem::path(std::to_string(E)) / "proof";
+}
+
+bool ProofSet::isValidTo(uint32_t limitK) const {
+  // Check if we have all required checkpoint files up to limitK
+  for (uint32_t point : points) {
+    if (point > limitK) break;
+    if (point < E && !fileExists(point)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool ProofSet::fileExists(uint32_t k) const {
+  auto filePath = proofPath(E) / std::to_string(k);
+  return std::filesystem::exists(filePath);
+}
+
+std::vector<uint32_t> ProofSet::load(uint32_t iter) const {
+  if (!shouldCheckpoint(iter)) {
+    throw std::runtime_error("Attempt to load non-checkpoint iteration: " + std::to_string(iter));
+  }
+
+  auto filePath = proofPath(E) / std::to_string(iter);
+  std::ifstream file(filePath, std::ios::binary);
+  if (!file) {
+    throw std::runtime_error("Cannot open proof checkpoint file: " + filePath.string());
+  }
+
+  // Read CRC32 first
+  uint32_t crc;
+  file.read(reinterpret_cast<char*>(&crc), sizeof(crc));
+  if (!file.good()) {
+    throw std::runtime_error("Error reading CRC32 from proof checkpoint file: " + filePath.string());
+  }
+
+  // Calculate expected file size in 32-bit words: (E + 31) / 32
+  uint32_t expectedWords = (E + 31) / 32;
+  
+  // Read the 32-bit words data
+  std::vector<uint32_t> words(expectedWords);
+  file.read(reinterpret_cast<char*>(words.data()), expectedWords * sizeof(uint32_t));
+  if (!file.good()) {
+    throw std::runtime_error("Error reading data from proof checkpoint file: " + filePath.string());
+  }
+
+  // Verify CRC32
+  uint32_t computedCrc = computeCRC32(words.data(), words.size() * sizeof(uint32_t));
+  if (crc != computedCrc) {
+    throw std::runtime_error("CRC32 mismatch in proof checkpoint file: " + filePath.string());
+  }
+
+  return words;
+}
+
+Proof ProofSet::computeProof() const {
+  // Start timing proof generation
+  util::Timer timer;
+
+  std::vector<std::vector<uint32_t>> middles;
+  std::vector<uint64_t> hashes;
+
+  // Initial hash of the final residue B
+  auto B = load(E);
+  auto hash = Proof::hashWords(E, B);
+
+  // Pre-allocate maximum needed buffer pool (power levels use 2^p buffers max)
+  uint32_t maxBuffers = (1u << power);
+  std::vector<mpz_class> bufferPool(maxBuffers);
+
+  // Main computation loop
+  for (uint32_t p = 0; p < power; ++p) {
+    assert(p == hashes.size());
+    
+    uint32_t s = (1u << (power - p - 1)); // Step size for this level
+    uint32_t levelBuffers = (1u << p); // Number of buffers needed for this level
+    uint32_t bufIndex = 0;
+    
+    // Clear buffers that will be used for this level
+    for (uint32_t i = 0; i < levelBuffers; ++i) {
+      bufferPool[i] = 0;
+    }
+    
+    // Load residues and apply binary tree algorithm
+    for (uint32_t i = 0; i < levelBuffers; ++i) {
+      // PRPLL's formula: load checkpoint at points[s * (i * 2 + 1) - 1]
+      uint32_t checkpointIndex = s * (i * 2 + 1) - 1;
+      
+      if (checkpointIndex >= points.size()) {
+        continue;
+      }
+      
+      uint32_t iteration = points[checkpointIndex];
+      
+      if (iteration > E || !shouldCheckpoint(iteration)) {
+        continue;
+      }
+      
+      auto w = load(iteration);
+      bufferPool[bufIndex] = convertToGMP(w);
+      bufIndex++;
+      
+      // Apply hashes from previous levels
+      for (uint32_t k = 0; i & (1u << k); ++k) {
+        assert(k <= p - 1);
+        if (bufIndex < 2) {
+          std::cerr << "Error: need at least 2 buffers for expMul, have " << bufIndex << std::endl;
+          continue;
+        }
+        
+        bufIndex--;
+        uint64_t h = hashes[p - 1 - k]; // Hash from previous level
+        
+        // PRPLL's expMul: (bufIndex-1) := (bufIndex-1)^h * bufIndex
+        mpz_class temp = mersennePowMod(bufferPool[bufIndex - 1], h, E); // A^h mod (2^E - 1)
+        mpz_class result = temp * bufferPool[bufIndex]; // A^h * B
+        bufferPool[bufIndex - 1] = mersenneReduce(result, E); // Optimized Mersenne reduction
+        
+        // Clear the consumed buffer
+        bufferPool[bufIndex] = 0;
+      }
+    }
+    
+    if (bufIndex != 1) {
+      std::cerr << "Warning: expected bufIndex=1, got " << bufIndex << std::endl;
+    }
+    
+    // Convert the final result to words format
+    auto levelResult = convertFromGMP(bufferPool[0]);
+    
+    if (levelResult.empty()) {
+      throw std::runtime_error("Read ZERO during proof generation at level " + std::to_string(p));
+    }
+    
+    // Store the result as middle for this level
+    middles.push_back(levelResult);
+    
+    // Update hash chain with this level's middle
+    hash = Proof::hashWords(E, hash, levelResult);
+    uint64_t newHash = hash[0]; // The first 64 bits of the hash
+    hashes.push_back(newHash);
+    
+    // Show middle and hash for the current level
+    uint64_t middleRes64 = Proof::res64(levelResult);
+    std::cout << "proof [" << p << "] : M " << std::hex << std::setfill('0') << std::setw(16) << middleRes64 
+              << ", h " << std::setw(16) << newHash << std::dec << std::endl;
+  }
+  
+  // Display proof generation time
+  double elapsed = timer.elapsed();
+  std::cout << "Proof generated in " << std::fixed << std::setprecision(2) << elapsed << " seconds." << std::endl;
+  
+  return Proof{E, std::move(B), std::move(middles)};
+}
+
+mpz_class ProofSet::convertToGMP(const std::vector<uint32_t>& words) const {
+  mpz_class result;
+  // Use GMP's optimized mpz_import function
+  mpz_import(result.get_mpz_t(), words.size(), -1 /*order: LSWord first*/, sizeof(uint32_t), 0 /*endian: native*/, 0 /*nails*/, words.data());
+  return result;
+}
+
+// Optimized modular reduction for Mersenne numbers: x mod (2^E - 1)
+// Uses the identity: X mod (2^E - 1) ≡ (Xlo + Xhi) mod (2^E - 1)
+mpz_class ProofSet::mersenneReduce(const mpz_class& x, uint32_t E) const {
+  // For small numbers, use regular mod
+  if (mpz_sizeinbase(x.get_mpz_t(), 2) <= E + 1) {
+    return x;
+  }
+  
+  // Create Mersenne modulus: 2^E - 1
+  mpz_class mersenne_mod = 1;
+  mersenne_mod <<= E;
+  mersenne_mod -= 1;
+  
+  // Split x into high and low parts
+  // xlo = x & (2^E - 1)  (low E bits)
+  mpz_class xlo = x & mersenne_mod;
+  
+  // xhi = x >> E  (remaining high bits)
+  mpz_class xhi = x >> E;
+  
+  // Add high and low parts
+  mpz_class result = xlo + xhi;
+  
+  // If result >= 2^E - 1, subtract the modulus
+  if (result >= mersenne_mod) {
+    result -= mersenne_mod;
+  }
+  
+  return result;
+}
+
+// Optimized modular exponentiation for Mersenne numbers: base^exp mod (2^E - 1)
+// Uses fast Mersenne reduction at each step instead of general division
+mpz_class ProofSet::mersennePowMod(const mpz_class& base, uint64_t exp, uint32_t E) const {
+  if (exp == 0) {
+    return mpz_class(1);
+  }
+  
+  if (exp == 1) {
+    return mersenneReduce(base, E);
+  }
+  
+  // Initialize result to 1
+  mpz_class result = 1;
+  
+  // Copy base and reduce it
+  mpz_class square = mersenneReduce(base, E);
+  
+  // Binary exponentiation with fast Mersenne reduction
+  while (exp > 0) {
+    if (exp & 1) {
+      // result = result * square mod (2^E - 1)
+      mpz_class temp = result * square;
+      result = mersenneReduce(temp, E);
+    }
+    
+    exp >>= 1;
+    if (exp > 0) {
+      // square = square * square mod (2^E - 1)
+      mpz_class temp = square * square;
+      square = mersenneReduce(temp, E);
+    }
+  }
+  
+  return result;
+}
+
+std::vector<uint32_t> ProofSet::convertFromGMP(const mpz_class& gmp_val) const {
+  size_t wordCount = (E + 31) / 32;
+  std::vector<uint32_t> data(wordCount, 0);
+  
+  // Use GMP's optimized mpz_export function
+  size_t actualWords = 0;
+  mpz_export(data.data(), &actualWords, -1 /*order: LSWord first*/, sizeof(uint32_t), 0 /*endian: native*/, 0 /*nails*/, gmp_val.get_mpz_t());
+  
+  // Note: actualWords may be less than wordCount if the number has leading zeros
+  // The vector is already zero-initialized, so this is correct
+  return data;
+}
+
+double ProofSet::diskUsageGB(uint32_t E, uint32_t power) {
+  // Calculate disk usage in GB for proof files
+  // Formula from PRPLL: ldexp(E, -33 + int(power)) * 1.05
+  if (power == 0) return 0.0;
+  return std::ldexp(static_cast<double>(E), -33 + static_cast<int>(power)) * 1.05;
 }
 
 } // namespace core

--- a/src/io/JsonBuilder.cpp
+++ b/src/io/JsonBuilder.cpp
@@ -75,7 +75,7 @@ namespace io{
         doDiv3(E, W);
         doDiv3(E, W);
     }
-static std::vector<uint32_t> compactBits(
+std::vector<uint32_t> JsonBuilder::compactBits(
     const std::vector<uint64_t>& x,
     const std::vector<int>&      digit_width,
     uint32_t                     E
@@ -267,7 +267,7 @@ std::string JsonBuilder::generate(const std::vector<uint64_t>& x,
 {
     
     
-   auto words = compactBits(x, digit_width, opts.exponent);
+   auto words = JsonBuilder::compactBits(x, digit_width, opts.exponent);
     if (opts.mode == "prp") doDiv9(opts.exponent, words);
     if (words.size() < 64) {
         words.resize(64, 0);
@@ -352,7 +352,7 @@ std::string JsonBuilder::computeRes64(
     double /*elapsed*/,
     int /*transform_size*/)
 {
-    auto words = compactBits(x, digit_width, opts.exponent);
+    auto words = JsonBuilder::compactBits(x, digit_width, opts.exponent);
     if (opts.mode == "prp") doDiv9(opts.exponent, words);
     uint64_t finalRes64 = (uint64_t(words[1]) << 32) | words[0];
     std::ostringstream oss;
@@ -368,7 +368,7 @@ std::string JsonBuilder::computeRes64Iter(
     double /*elapsed*/,
     int /*transform_size*/)
 {
-    auto words = compactBits(x, digit_width, opts.exponent);
+    auto words = JsonBuilder::compactBits(x, digit_width, opts.exponent);
     //if (opts.mode == "prp") doDiv9(opts.exponent, words);
     uint64_t finalRes64 = (uint64_t(words[1]) << 32) | words[0];
     std::ostringstream oss;
@@ -385,7 +385,7 @@ std::string JsonBuilder::computeRes2048(
     double /*elapsed*/,
     int /*transform_size*/)
 {
-    auto words = compactBits(x, digit_width, opts.exponent);
+    auto words = JsonBuilder::compactBits(x, digit_width, opts.exponent);
     if (opts.mode == "prp") doDiv9(opts.exponent, words);
     std::ostringstream oss;
     for (int i = 63; i >= 0; --i) {

--- a/src/io/JsonBuilder.cpp
+++ b/src/io/JsonBuilder.cpp
@@ -200,14 +200,14 @@ static std::string generatePrimeNetJson(
         << "\"errors\":{\"gerbicz\":" << gerbiczError << "},"
         << "\"fft-length\":"  << fftLength            << ","
         << "\"shift-count\":0,";
-   /* if (isPRP) {
+    if (isPRP && !proofMd5.empty()) {
         oss << "\"proof\":{"
             << "\"version\":"   << proofVersion         << ","
             << "\"power\":"     << proofPower           << ","
             << "\"hashsize\":"  << proofHashSize        << ","
             << "\"md5\":"       << jsonEscape(proofMd5)
             << "},";
-    }*/
+    }
     oss << "\"program\":{"
         << "\"name\":"      << jsonEscape(programName)
         << ",\"version\":"  << jsonEscape(programVersion)
@@ -325,7 +325,7 @@ std::string JsonBuilder::generate(const std::vector<uint64_t>& x,
         1,  // residueType
         0,  // gerbiczError
         transform_size,
-        opts.proof ? 1 : 0,
+        opts.proof ? 2 : 0,
         opts.proof ? opts.proofPower : 0,
         opts.proof ? 64 : 0,
         opts.proof ? fileMD5(opts.proofFile) : "",

--- a/src/util/Crc32.cpp
+++ b/src/util/Crc32.cpp
@@ -96,12 +96,21 @@ static const uint32_t crctable[256] = {
 #define CRC32_INIT_VALUE 0xffffffffUL
 #define CRC32_XOR_VALUE  0xffffffffUL
 
-unsigned int computeCRC32(const std::string &data) {
+uint32_t computeCRC32(const std::string &data) {
     uint32_t crc = CRC32_INIT_VALUE;
     for (unsigned char c : data) {
         crc = crctable[(crc ^ c) & 0xFF] ^ (crc >> 8);
     }
     return static_cast<unsigned int>(crc ^ CRC32_XOR_VALUE);
+}
+
+uint32_t computeCRC32(const void* data, size_t size) {
+    uint32_t crc = CRC32_INIT_VALUE;
+    const uint8_t* bytes = static_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < size; ++i) {
+        crc = crctable[(crc ^ bytes[i]) & 0xFF] ^ (crc >> 8);
+    }
+    return crc ^ CRC32_XOR_VALUE;
 }
 
 std::string toLower(const std::string &s) {


### PR DESCRIPTION
In this pull request I attempt to implement proof file generation in PrMers. The implementation is heavily inspired by GpuOwl/PRPLL. I used GMP library to implement computations required to generate a proof file on the CPU. GMP library can be installed on Ubuntu by running `sudo apt install libgmp-dev`. I tested it and it appears to be working correctly, however it is somewhat slow.. The better implementation might be to do those computations on the GPU, the same way as PRPLL does. This pull request might benefit from more testing and thorough code review and maybe also some refactoring. The next feature to implement might be proof file verification, which will make it possible to self-verify generated proof files.

The main changes include:
- use of GMP library for large number arithmetic on CPU
- implementation of `ProofSet` methods for saving and loading checkpoints
- `computeProof` method to generate a proof file from a set of checkpoints
- `Proof` class for saving and loading of proof files
- printing of proof metadata (version, proof level, md5 hash) in JSON results
- integration of checkpoint and proof file saving in main computation pipeline
- separate measurement of GPU computation time and proof generation time