### PR TITLE
Ensure best proof power to be within bounds

### DIFF
--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -449,15 +449,11 @@ int App::runPrpOrLl() {
     // Display proof disk usage estimate at start of computation
     if (options.proof) {
         int proofPower = ProofSet::bestPower(options.exponent);
-            if(proofPower>=2 && proofPower < 13){
-            options.proofPower = proofPower;
-            double diskUsageGB = ProofSet::diskUsageGB(options.exponent, proofPower);
-            std::cout << "Proof of power " << proofPower << " requires about "
-                    << std::fixed << std::setprecision(2) << diskUsageGB
-                    << "GB of disk space" << std::endl;
-            }else{
-                options.proof = false;
-            }
+        options.proofPower = proofPower;
+        double diskUsageGB = ProofSet::diskUsageGB(options.exponent, proofPower);
+        std::cout << "Proof of power " << proofPower << " requires about "
+                << std::fixed << std::setprecision(2) << diskUsageGB
+                << "GB of disk space" << std::endl;
     }
 
     logger.logStart(options);

--- a/src/core/ProofSet.cpp
+++ b/src/core/ProofSet.cpp
@@ -131,10 +131,10 @@ uint32_t ProofSet::bestPower(uint32_t E) {
 
   //assert(E > 0);
   // log2(x)/2 is log4(x)
-  uint32_t power = 10 + std::floor(std::log2(E / 60e6) / 2);
-  power = std::max(power, 2u);
-  power = std::min(power, 12u);
-  return power;
+  int32_t power = 10 + static_cast<int32_t>(std::floor(std::log2(E / 60e6) / 2));
+  power = std::max(power, 2);
+  power = std::min(power, 12);
+  return static_cast<uint32_t>(power);
 }
 
 bool ProofSet::isInPoints(uint32_t E, uint32_t power, uint32_t k) {

--- a/src/core/ProofSet.cpp
+++ b/src/core/ProofSet.cpp
@@ -56,9 +56,6 @@ ProofSet::ProofSet(uint32_t exponent, uint32_t proofLevel)
   : E{exponent}, power{proofLevel} {
   
   assert(E & 1); // E is supposed to be prime
-  /*if (power <= 0 || power > 12) {
-    throw std::runtime_error("Invalid proof power: " + std::to_string(power));
-  }*/
 
   // Create proof directory
   std::filesystem::create_directories(proofPath(E));
@@ -134,9 +131,10 @@ uint32_t ProofSet::bestPower(uint32_t E) {
 
   //assert(E > 0);
   // log2(x)/2 is log4(x)
-  int power = 10 + std::floor(std::log2(E / 60e6) / 2);
-  //assert(power >= 2);
-  return static_cast<uint32_t>(power);
+  uint32_t power = 10 + std::floor(std::log2(E / 60e6) / 2);
+  power = std::max(power, 2u);
+  power = std::min(power, 12u);
+  return power;
 }
 
 bool ProofSet::isInPoints(uint32_t E, uint32_t power, uint32_t k) {


### PR DESCRIPTION
I think that we can ensure that recommended proof power, as return by `bestPower` function, is within bounds inside this function itself, instead of checking it in other places across the codebase. This will fix bug with too low proof power being selected for small exponents.