### PR TITLE
PRP tests on Mersenne cofactors

### DIFF
--- a/include/core/Printer.hpp
+++ b/include/core/Printer.hpp
@@ -10,11 +10,9 @@ class Printer {
 public:
     static void banner(const io::CliOptions& opts);
     static bool finalReport(const io::CliOptions& opts,
-                          const std::vector<uint64_t>& resultVec,
-                          std::string res64,                          
-                          uint64_t n,
-                          const std::string& timestampBuf,
-                          double elapsed, std::string jsonResult);
+                          double elapsed,
+                          const std::string& jsonResult,
+                          bool isPrime);
     static void displayVector(const std::vector<uint64_t>& vec, const std::string& label = "Vector");
 
 };

--- a/include/core/Proof.hpp
+++ b/include/core/Proof.hpp
@@ -11,9 +11,10 @@ public:
     const uint32_t E;
     const std::vector<uint32_t> B;
     const std::vector<std::vector<uint32_t>> middles;
+    const std::vector<std::string> knownFactors;
 
-    Proof(uint32_t exponent, std::vector<uint32_t> finalResidue, std::vector<std::vector<uint32_t>> intermediateResidues)
-        : E(exponent), B(std::move(finalResidue)), middles(std::move(intermediateResidues)) {}
+    Proof(uint32_t exponent, std::vector<uint32_t> finalResidue, std::vector<std::vector<uint32_t>> intermediateResidues, std::vector<std::string> factors = {})
+        : E(exponent), B(std::move(finalResidue)), middles(std::move(intermediateResidues)), knownFactors(std::move(factors)) {}
 
     // File I/O methods for proof files
     void save(const std::filesystem::path& filePath) const;

--- a/include/core/ProofManager.hpp
+++ b/include/core/ProofManager.hpp
@@ -19,7 +19,8 @@ class ProofManager {
 public:
     ProofManager(uint32_t exponent, int proofLevel,
                  cl_command_queue queue, uint32_t n,
-                 const std::vector<int>& digitWidth);
+                 const std::vector<int>& digitWidth,
+                 const std::vector<std::string>& knownFactors = {});
     void checkpoint(cl_mem buf, uint32_t iter);    
     std::filesystem::path proof() const;
 

--- a/include/core/ProofSet.hpp
+++ b/include/core/ProofSet.hpp
@@ -25,8 +25,9 @@ class ProofSet {
 public:
     const uint32_t E;     // exponent
     const uint32_t power; // proof power level
+    const std::vector<std::string> knownFactors; // known factors (for cofactor tests)
 
-    ProofSet(uint32_t exponent, uint32_t proofLevel);
+    ProofSet(uint32_t exponent, uint32_t proofLevel, std::vector<std::string> factors = {});
 
     bool shouldCheckpoint(uint32_t iter) const;
     void save(uint32_t iter, const std::vector<uint32_t>& words);

--- a/include/core/ProofSet.hpp
+++ b/include/core/ProofSet.hpp
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <vector>
 #include <filesystem>
-#include <gmpxx.h>
 
 namespace core {
 
@@ -47,12 +46,6 @@ private:
     
     bool isValidTo(uint32_t limitK) const;
     bool fileExists(uint32_t k) const;
-    
-    // GMP-based modular arithmetic helpers
-    mpz_class convertToGMP(const std::vector<uint32_t>& words) const;
-    std::vector<uint32_t> convertFromGMP(const mpz_class& gmp_val) const;
-    mpz_class mersenneReduce(const mpz_class& x, uint32_t E) const;
-    mpz_class mersennePowMod(const mpz_class& base, uint64_t exp, uint32_t E) const;
 };
 
 } // namespace core

--- a/include/io/CliParser.hpp
+++ b/include/io/CliParser.hpp
@@ -52,6 +52,7 @@ struct CliOptions {
     std::string uid = "";
     int res64_display_interval = 0;
     bool cl_queue_throttle_active = false;
+    std::vector<std::string> knownFactors;
 };
 
 class CliParser {

--- a/include/io/JsonBuilder.hpp
+++ b/include/io/JsonBuilder.hpp
@@ -2,6 +2,7 @@
 #define IO_JSONBUILDER_HPP
 
 #include <string>
+#include <tuple>
 #ifndef CL_TARGET_OPENCL_VERSION
 #define CL_TARGET_OPENCL_VERSION 300
 #endif
@@ -18,11 +19,16 @@ namespace io {
 
 class JsonBuilder {
 public:
-    static std::string generate(const std::vector<uint64_t>& x,
-                                 const CliOptions& opts,
-                                 const std::vector<int>& digit_width,
-                                 double elapsed,
-                                 int transform_size);
+    static std::tuple<bool, std::string, std::string> computeResult(
+        const std::vector<uint64_t>& hostResult,
+        const CliOptions& opts,
+        const std::vector<int>& digit_width);
+
+    static std::string generate(const CliOptions& opts,
+                                 int transform_size,
+                                 bool isPrime,
+                                 const std::string& res64,
+                                 const std::string& res2048);
 
     // Write JSON string to a file.
     static void write(const std::string& json,

--- a/include/io/WorktodoParser.hpp
+++ b/include/io/WorktodoParser.hpp
@@ -3,6 +3,7 @@
 #include <optional>
 #include <string>
 #include <cstdint>
+#include <vector>
 
 namespace io {
 
@@ -12,6 +13,9 @@ struct WorktodoEntry {
     uint32_t exponent;
     std::string aid;
     std::string rawLine;  
+    // Cofactor test support
+    std::vector<std::string> knownFactors;  // List of known factors as strings
+    uint32_t residueType = 1;               // Default Type 1, Type 5 for cofactors
 };
 
 class WorktodoParser {

--- a/include/math/Cofactor.hpp
+++ b/include/math/Cofactor.hpp
@@ -10,6 +10,16 @@ class Cofactor {
 public:
     // Check that factors actually divide the Mersenne number
     static bool validateFactors(uint32_t exponent, const std::vector<std::string>& factors);
+    
+    // Check if the cofactor is PRP based on the final computed residue
+    // KF = product(known_factors)
+    // N = (2^p - 1) / KF
+    // residue == base^(KF-1) (mod N)
+    static bool isCofactorPRP(uint32_t exponent,
+                              const std::vector<std::string>& factors,
+                              const std::vector<uint32_t>& finalResidue,
+                              uint32_t base = 3);
+
 };
 
 } // namespace math

--- a/include/math/Cofactor.hpp
+++ b/include/math/Cofactor.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#include <vector>
+#include <string>
+#include <cstdint>
+
+namespace math {
+
+// Utilities for Mersenne cofactor tests
+class Cofactor {
+public:
+    // Check that factors actually divide the Mersenne number
+    static bool validateFactors(uint32_t exponent, const std::vector<std::string>& factors);
+};
+
+} // namespace math

--- a/include/util/GmpUtils.hpp
+++ b/include/util/GmpUtils.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+#include <gmpxx.h>
+
+// GMP-based modular arithmetic helpers
+namespace util {
+    mpz_class convertToGMP(const std::vector<uint32_t>& words);
+    std::vector<uint32_t> convertFromGMP(const mpz_class& gmp_val);
+    mpz_class mersenneReduce(const mpz_class& x, uint32_t E);
+    mpz_class mersennePowMod(const mpz_class& base, uint64_t exp, uint32_t E);
+}

--- a/include/util/StringUtils.hpp
+++ b/include/util/StringUtils.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include <vector>
+#include <string>
+
+namespace util {
+
+std::vector<std::string> split(const std::string& s, char sep);
+
+} // namespace util

--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -340,7 +340,8 @@ App::App(int argc, char** argv)
         options.proof ? ProofSet::bestPower(options.exponent) : 0,
         context.getQueue(),
         precompute.getN(),
-        precompute.getDigitWidth()
+        precompute.getDigitWidth(),
+        options.knownFactors
     )
   , spinner()
   , logger(options.output_path)

--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -49,6 +49,7 @@
 #include <string>
 #include <cstring>
 #include <sstream>
+#include <tuple>
 #include <atomic>
 #include <fstream>
 #include <memory>
@@ -1179,11 +1180,11 @@ int App::runPrpOrLl() {
             std::cout << std::endl;
         }
         res64_x = io::JsonBuilder::computeRes64(
-        hostData,
-        options,
-        precompute.getDigitWidth(),
-        timer.elapsed(),
-        static_cast<int>(context.getTransformSize())
+            hostData,
+            options,
+            precompute.getDigitWidth(),
+            timer.elapsed(),
+            static_cast<int>(context.getTransformSize())
         );
         
         spinner.displayProgress(
@@ -1219,16 +1220,6 @@ int App::runPrpOrLl() {
     
 
     double finalElapsed = timer.elapsed();
-
-    std::string json = io::JsonBuilder::generate(
-        hostData,
-        options,
-        precompute.getDigitWidth(),
-        finalElapsed,
-        static_cast<int>(context.getTransformSize())
-    );
-
-
     logger.logEnd(finalElapsed);
 
     std::vector<uint64_t> hostResult(precompute.getN());
@@ -1241,29 +1232,23 @@ int App::runPrpOrLl() {
         0, nullptr, nullptr
     );
 
-    //std::time_t t = std::chrono::system_clock::to_time_t(now2);
-    char timestampBuf[32];
-    std::time_t t = std::time(nullptr);
-    std::tm timeinfo;
 
-    #ifdef _WIN32
-        gmtime_s(&timeinfo, &t);
-    #else
-        std::tm* tmp = std::gmtime(&t);
-        if (tmp != nullptr)
-            timeinfo = *tmp;
-    #endif
+    auto [isPrime, res64, res2048] = io::JsonBuilder::computeResult(hostResult, options, precompute.getDigitWidth());
 
-    std::strftime(timestampBuf, sizeof(timestampBuf), "%Y-%m-%dT%H:%M:%SZ", &timeinfo);
+    std::string json = io::JsonBuilder::generate(
+        options,
+        static_cast<int>(context.getTransformSize()),
+        isPrime,
+        res64,
+        res2048
+    );
+
 
     Printer::finalReport(
         options,
-        hostResult,
-        res64_x,
-        precompute.getN(),
-        timestampBuf,
         finalElapsed,
-        json
+        json,
+        isPrime
     );
     bool skippedSubmission = false;
 
@@ -1309,14 +1294,6 @@ int App::runPrpOrLl() {
     }
 
 
-    bool isPrime = (options.mode == "prp")
-                   ? (hostResult[0] == 9
-                      && std::all_of(hostResult.begin()+1,
-                                     hostResult.end(),
-                                     [](uint64_t v){ return v == 0; }))
-                   : std::all_of(hostResult.begin(),
-                                 hostResult.end(),
-                                 [](uint64_t v){ return v == 0; });
     backupManager.clearState();
     io::WorktodoManager wm(options);
     wm.saveIndividualJson(options.exponent, options.mode, json);

--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -310,6 +310,7 @@ App::App(int argc, char** argv)
           o.exponent = e->exponent;
           o.mode     = e->prpTest ? "prp" : "ll";
           o.aid      = e->aid;
+          o.knownFactors = e->knownFactors;
           hasWorktodoEntry_ = true;
       }
       if (!hasWorktodoEntry_ && o.exponent == 0) {

--- a/src/core/Printer.cpp
+++ b/src/core/Printer.cpp
@@ -42,24 +42,15 @@ void Printer::banner(const io::CliOptions& o) {
 }
 
 bool Printer::finalReport(const io::CliOptions& opts,
-                          const std::vector<uint64_t>& resultVec,
-                          std::string res64,
-                          uint64_t n,
-                          const std::string& timestampBuf,
-                          double elapsed, std::string jsonResult) {
+                          double elapsed,
+                          const std::string& jsonResult,
+                          bool isPrime) {
     const uint32_t p = opts.exponent;
     const std::string& mode = opts.mode;
 
-    bool isPrime = false;
-    std::string statusCode;
-
     if (mode == "ll") {
-        isPrime = std::all_of(resultVec.begin(), resultVec.end(), [](uint64_t v) { return v == 0; });
-        statusCode = isPrime ? "P" : "C";
         std::cout << "\nM" << p << " is " << (isPrime ? "prime" : "composite") << ".\n";
     } else {
-        isPrime = (resultVec[0] == 9) && std::all_of(resultVec.begin() + 1, resultVec.end(), [](uint64_t v) { return v == 0; });
-        statusCode = isPrime ? "P" : "C";
         std::cout << "\nM" << p << " PRP test: " << (isPrime ? "probably prime (residue is 9)" : "composite") << ".\n";
     }
 

--- a/src/core/Printer.cpp
+++ b/src/core/Printer.cpp
@@ -51,7 +51,15 @@ bool Printer::finalReport(const io::CliOptions& opts,
     if (mode == "ll") {
         std::cout << "\nM" << p << " is " << (isPrime ? "prime" : "composite") << ".\n";
     } else {
-        std::cout << "\nM" << p << " PRP test: " << (isPrime ? "probably prime (residue is 9)" : "composite") << ".\n";
+        if (!opts.knownFactors.empty()) {
+            std::cout << "\nM" << p;
+            for (const auto& factor : opts.knownFactors) {
+                std::cout << "/" << factor;
+            }
+            std::cout << " PRP test: " << (isPrime ? "probably prime" : "composite") << ".\n";
+        } else {
+            std::cout << "\nM" << p << " PRP test: " << (isPrime ? "probably prime (residue is 9)" : "composite") << ".\n";
+        }
     }
 
     std::cout << "\nManual submission JSON:\n" << jsonResult << std::endl;

--- a/src/core/ProofManager.cpp
+++ b/src/core/ProofManager.cpp
@@ -29,8 +29,9 @@ namespace core {
 
 ProofManager::ProofManager(uint32_t exponent, int proofLevel,
                            cl_command_queue queue, uint32_t n,
-                           const std::vector<int>& digitWidth)
-  : proofSet_(exponent, proofLevel)
+                           const std::vector<int>& digitWidth,
+                           const std::vector<std::string>& knownFactors)
+  : proofSet_(exponent, proofLevel, knownFactors)
   , queue_(queue)
   , n_(n)
   , exponent_(exponent)

--- a/src/core/ProofSet.cpp
+++ b/src/core/ProofSet.cpp
@@ -53,8 +53,8 @@ Words Words::fromUint64(const std::vector<uint64_t>& host, uint32_t exponent) {
 }
 
 // ProofSet
-ProofSet::ProofSet(uint32_t exponent, uint32_t proofLevel)
-  : E{exponent}, power{proofLevel} {
+ProofSet::ProofSet(uint32_t exponent, uint32_t proofLevel, std::vector<std::string> factors)
+  : E{exponent}, power{proofLevel}, knownFactors{std::move(factors)} {
   if(exponent%2!=0){
       assert(E & 1); // E is supposed to be prime
     
@@ -307,7 +307,7 @@ Proof ProofSet::computeProof() const {
   double elapsed = timer.elapsed();
   std::cout << "Proof generated in " << std::fixed << std::setprecision(2) << elapsed << " seconds." << std::endl;
   
-  return Proof{E, std::move(B), std::move(middles)};
+  return Proof{E, std::move(B), std::move(middles), knownFactors};
 }
 
 double ProofSet::diskUsageGB(uint32_t E, uint32_t power) {

--- a/src/io/CliParser.cpp
+++ b/src/io/CliParser.cpp
@@ -21,6 +21,7 @@
  * This code is released as free software. 
  */
 #include "io/CliParser.hpp"
+#include "util/StringUtils.hpp"
 #include <iostream>
 #include <cstdlib>
 #include <cstring>
@@ -227,6 +228,9 @@ CliOptions CliParser::parse(int argc, char** argv ) {
         else if (std::strcmp(argv[i], "-gerbiczli") == 0 || std::strcmp(argv[i], "-gerbiczli") == 0) {
             opts.gerbiczli = false;
         }
+        else if (strcmp(argv[i], "-factors") == 0 && i + 1 < argc) {
+            opts.knownFactors = util::split(argv[++i], ',');
+        }
         else if (argv[i][0] != '-') {
             if (opts.exponent == 0) {
                 opts.exponent = std::strtoull(argv[i], nullptr, 10);
@@ -243,6 +247,14 @@ CliOptions CliParser::parse(int argc, char** argv ) {
     if(opts.mode == "ll"){
         opts.erroriter = 0;
     }
+    
+    // Check that LL test is not used for Mersenne cofactors
+    if (opts.mode == "ll" && !opts.knownFactors.empty()) {
+        std::cerr << "Error: Lucas-Lehmer test cannot be used on Mersenne cofactors." << std::endl;
+        std::cerr << "Use PRP test for Mersenne cofactors instead." << std::endl;
+        std::exit(EXIT_FAILURE);
+    }
+    
     if(opts.iterforce == 0){
         opts.iterforce = 500;
     }

--- a/src/io/JsonBuilder.cpp
+++ b/src/io/JsonBuilder.cpp
@@ -21,6 +21,7 @@
  */
 #include "io/JsonBuilder.hpp"
 #include "io/CliParser.hpp"          // for CliOptions
+#include "math/Cofactor.hpp"
 #ifndef CL_TARGET_OPENCL_VERSION
 #define CL_TARGET_OPENCL_VERSION 300
 #endif
@@ -90,11 +91,16 @@ std::tuple<bool, std::string, std::string> JsonBuilder::computeResult(
     
     bool isPrime;
     if (opts.mode == "prp") {
-        // Mersenne number PRP
-        isPrime = (hostResult[0] == 9
-                    && std::all_of(hostResult.begin()+1,
-                                    hostResult.end(),
-                                    [](uint64_t v){ return v == 0; }));
+        if (!opts.knownFactors.empty()) {
+            // Mersenne cofactor PRP
+            isPrime = math::Cofactor::isCofactorPRP(opts.exponent, opts.knownFactors, words);
+        } else {
+            // Mersenne number PRP
+            isPrime = (hostResult[0] == 9
+                       && std::all_of(hostResult.begin()+1,
+                                      hostResult.end(),
+                                      [](uint64_t v){ return v == 0; }));
+        }
     } else {
         // Mersenne number LL
         isPrime = std::all_of(hostResult.begin(),

--- a/src/io/JsonBuilder.cpp
+++ b/src/io/JsonBuilder.cpp
@@ -239,7 +239,8 @@ static std::string generatePrimeNetJson(
     const std::string &aid,
     const std::string &uid,
     const std::string &timestamp,
-    const std::string &computer)
+    const std::string &computer,
+    const std::vector<std::string>& knownFactors)
 {
     std::ostringstream oss;
     bool isPRP = (worktype.rfind("PRP", 0) == 0);
@@ -276,6 +277,17 @@ static std::string generatePrimeNetJson(
     if (!aid.empty())      oss << ",\"aid\":"      << jsonEscape(aid);
     if (!uid.empty())      oss << ",\"uid\":"      << jsonEscape(uid);
     oss << ",\"timestamp\":" << jsonEscape(timestamp);
+
+    if (!knownFactors.empty()) {
+        oss << ",\"known-factors\":[";
+        for (size_t i = 0; i < knownFactors.size(); ++i) {
+            oss << jsonEscape(knownFactors[i]);
+            if (i < knownFactors.size() - 1) {
+                oss << ",";
+            }
+        }
+        oss << "]";
+    }
 
     // build canonical string …
     std::string prefix = oss.str();
@@ -340,6 +352,9 @@ std::string JsonBuilder::generate(const CliOptions& opts,
 
     status = isPrime ? "P" : "C";
     
+    // Use Type 5 residue for Mersenne cofactors
+    int residueType = opts.knownFactors.empty() ? 1 : 5;
+    
     // assemble JSON
     return generatePrimeNetJson(
         // status: P or C
@@ -348,7 +363,7 @@ std::string JsonBuilder::generate(const CliOptions& opts,
         opts.mode == "prp" ? "PRP-3" : "LL",
         res64,
         res2048,
-        1,  // residueType
+        residueType,
         opts.gerbicz_error_count,  // gerbiczError
         transform_size,
         opts.proof ? 2 : 0,
@@ -365,7 +380,8 @@ std::string JsonBuilder::generate(const CliOptions& opts,
         opts.aid,                  // aid
         opts.uid,                  // uid
         timestampBuf,              // timestamp
-        opts.computer_name         // computer
+        opts.computer_name,        // computer
+        opts.knownFactors
     );
 
 }

--- a/src/io/JsonBuilder.cpp
+++ b/src/io/JsonBuilder.cpp
@@ -267,7 +267,7 @@ std::string JsonBuilder::generate(const std::vector<uint64_t>& x,
 {
     
     
-   auto words = JsonBuilder::compactBits(x, digit_width, opts.exponent);
+    auto words = JsonBuilder::compactBits(x, digit_width, opts.exponent);
     if (opts.mode == "prp") doDiv9(opts.exponent, words);
     if (words.size() < 64) {
         words.resize(64, 0);

--- a/src/io/WorktodoParser.cpp
+++ b/src/io/WorktodoParser.cpp
@@ -21,6 +21,7 @@
  */
 // io/WorktodoParser.cpp
 #include "io/WorktodoParser.hpp"
+#include "util/StringUtils.hpp"
 #include <fstream>
 #include <sstream>
 #include <iostream>
@@ -33,17 +34,6 @@ WorktodoParser::WorktodoParser(const std::string& filename)
   : filename_(filename)
 {}
 
-
-static std::vector<std::string> split(const std::string& s, char sep) {
-    std::vector<std::string> out;
-    size_t i = 0, j;
-    while ((j = s.find(sep, i)) != std::string::npos) {
-        out.push_back(s.substr(i, j-i));
-        i = j+1;
-    }
-    out.push_back(s.substr(i));
-    return out;
-}
 static bool isHex(const std::string& s) {
     if (s.size() != 32) return false;
     for (char c : s)
@@ -62,14 +52,14 @@ std::optional<WorktodoEntry> WorktodoParser::parse() {
     while (std::getline(file, line)) {
         if (line.empty() || line[0] == '#') continue;
 
-        auto top = split(line, '=');
+        auto top = util::split(line, '=');
         if (top.size() < 2) continue;
 
         bool isPRP  = (top[0] == "PRP" || top[0] == "PRPDC");
         bool isLL   = (top[0] == "Test" || top[0] == "DoubleCheck");
         if (!(isPRP || isLL)) continue;
 
-        auto parts = split(top[1], ',');
+        auto parts = util::split(top[1], ',');
         if (!parts.empty() && (parts[0].empty() || parts[0] == "N/A"))
             parts.erase(parts.begin());
 

--- a/src/math/Cofactor.cpp
+++ b/src/math/Cofactor.cpp
@@ -1,0 +1,33 @@
+#include "math/Cofactor.hpp"
+#include "util/GmpUtils.hpp"
+#include <gmpxx.h>
+#include <iostream>
+
+namespace math {
+
+// Check that factors actually divide the Mersenne number
+bool Cofactor::validateFactors(uint32_t exponent, const std::vector<std::string>& factors) {
+    mpz_class mersenne = (mpz_class{1} << exponent) - 1; // Compute 2^p - 1
+    
+    for (const auto& factorStr : factors) {
+      if (factorStr.empty()) {
+        std::cout << "Factor validation failed: empty factor string" << std::endl;
+        return false;
+      }
+      
+      mpz_class factor{factorStr};
+      if (factor <= 1) {
+        std::cout << "Factor validation failed: factor " << factorStr << " <= 1" << std::endl;
+        return false;
+      }
+      
+      if (mersenne % factor != 0) {
+        std::cout << "Factor validation failed: " << factorStr << " does not divide 2^" << exponent << "-1" << std::endl;
+        return false;
+      }      
+    }
+    
+    return true;
+}
+
+} // namespace math

--- a/src/util/GmpUtils.cpp
+++ b/src/util/GmpUtils.cpp
@@ -1,0 +1,92 @@
+#include "util/GmpUtils.hpp"
+
+namespace util {
+
+mpz_class convertToGMP(const std::vector<uint32_t>& words) {
+  mpz_class result;
+  // Use GMP's optimized mpz_import function
+  mpz_import(result.get_mpz_t(), words.size(), -1 /*order: LSWord first*/, sizeof(uint32_t), 0 /*endian: native*/, 0 /*nails*/, words.data());
+  return result;
+}
+
+// Optimized modular reduction for Mersenne numbers: x mod (2^E - 1)
+// Uses the identity: X mod (2^E - 1) ≡ (Xlo + Xhi) mod (2^E - 1)
+mpz_class mersenneReduce(const mpz_class& x, uint32_t E) {
+  // For small numbers, use regular mod
+  if (mpz_sizeinbase(x.get_mpz_t(), 2) <= E + 1) {
+    return x;
+  }
+  
+  // Create Mersenne modulus: 2^E - 1
+  mpz_class mersenne_mod = 1;
+  mersenne_mod <<= E;
+  mersenne_mod -= 1;
+  
+  // Split x into high and low parts
+  // xlo = x & (2^E - 1)  (low E bits)
+  mpz_class xlo = x & mersenne_mod;
+  
+  // xhi = x >> E  (remaining high bits)
+  mpz_class xhi = x >> E;
+  
+  // Add high and low parts
+  mpz_class result = xlo + xhi;
+  
+  // If result >= 2^E - 1, subtract the modulus
+  if (result >= mersenne_mod) {
+    result -= mersenne_mod;
+  }
+  
+  return result;
+}
+
+// Optimized modular exponentiation for Mersenne numbers: base^exp mod (2^E - 1)
+// Uses fast Mersenne reduction at each step instead of general division
+mpz_class mersennePowMod(const mpz_class& base, uint64_t exp, uint32_t E) {
+  if (exp == 0) {
+    return mpz_class(1);
+  }
+  
+  if (exp == 1) {
+    return mersenneReduce(base, E);
+  }
+  
+  // Initialize result to 1
+  mpz_class result = 1;
+  
+  // Copy base and reduce it
+  mpz_class square = mersenneReduce(base, E);
+  
+  // Binary exponentiation with fast Mersenne reduction
+  while (exp > 0) {
+    if (exp & 1) {
+      // result = result * square mod (2^E - 1)
+      mpz_class temp = result * square;
+      result = mersenneReduce(temp, E);
+    }
+    
+    exp >>= 1;
+    if (exp > 0) {
+      // square = square * square mod (2^E - 1)
+      mpz_class temp = square * square;
+      square = mersenneReduce(temp, E);
+    }
+  }
+  
+  return result;
+}
+
+std::vector<uint32_t> convertFromGMP(const mpz_class& gmp_val) {
+  size_t wordCount = (mpz_sizeinbase(gmp_val.get_mpz_t(), 2) + 31) / 32;
+  std::vector<uint32_t> data(wordCount, 0);
+  
+  // Use GMP's optimized mpz_export function
+  size_t actualWords = 0;
+  mpz_export(data.data(), &actualWords, -1 /*order: LSWord first*/, sizeof(uint32_t), 0 /*endian: native*/, 0 /*nails*/, gmp_val.get_mpz_t());
+  
+  // Note: actualWords may be less than wordCount if the number has leading zeros
+  // The vector is already zero-initialized, so this is correct
+  return data;
+}
+
+}

--- a/src/util/StringUtils.cpp
+++ b/src/util/StringUtils.cpp
@@ -1,0 +1,16 @@
+#include "util/StringUtils.hpp"
+
+namespace util {
+
+std::vector<std::string> split(const std::string& s, char sep) {
+    std::vector<std::string> out;
+    size_t i = 0, j;
+    while ((j = s.find(sep, i)) != std::string::npos) {
+        out.push_back(s.substr(i, j-i));
+        i = j+1;
+    }
+    out.push_back(s.substr(i));
+    return out;
+}
+
+} // namespace util

--- a/unit_tests.sh
+++ b/unit_tests.sh
@@ -236,4 +236,25 @@ else
     exit 1
 fi
 
+echo ""
+echo "=== Mersenne cofactor PRP tests ==="
+
+echo -n "Testing M2699 cofactor with 4 factors (composite)... "
+./prmers -noask -prp 2699 -factors 5399,307687,1187561,7570504839257 > "logs/cofactor_composite_2699.log" 2>&1  
+if [ $? -eq 0 ]; then
+    echo "❌ Unexpected success (should be composite)"
+    exit 1
+else
+    echo "✅"
+fi
+
+echo -n "Testing M2699 cofactor with 5 factors (PRP)... "
+./prmers -noask -prp 2699 -factors 5399,307687,1187561,7570504839257,1987104667810711 > "logs/cofactor_prime_2699.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "❌ Failed (see logs/cofactor_prime_2699.log)"
+    exit 1
+else
+    echo "✅"
+fi
+
 echo -e "\n🎉 All tests passed."


### PR DESCRIPTION
This PR implements support for PRP tests on Mersenne cofactors. The same computation that is used to test if a Mersenne number is PRP can be used to test if a Mersenne cofactor is PRP. This PR thus does not include any changes to GPU code, but only adds a check based on the final residue that is run on CPU and implemented using GMP.

To check if a Mersenne number is PRP we check if the final residue (after a divide by 9) is equal 1. For Mersenne cofactors we instead check if the final residue is equal to `3^(KF-1) mod ((2^p-1) / KF) `, where `KF` is a product of known factors.

This PR includes the following changes to support cofactor tests:
- core cofactor PRP testing logic in `math::Cofactor::isCofactorPRP` function
- `-factors` CLI option to specify known factors to run test on the cofactor
- worktodo parsing, result generation and proof file header generation are updated to support cofactors
- a unit test for cofactor testing

Note: [mersenne.ca](https://www.mersenne.ca/prp.php) contains a list of known cofactor PRPs that can be useful to implement more unit tests.

This PR also includes some general refactoring changes that allowed to implemented support for Mersenne cofactors in more straightforward way:
- the final residue test is now performed once in `JsonBuilder::computeResult` function,  previously it was performed in `JsonBuilder::generate`, `Printer::finalReport` and once more in `App::runPrpOrLl`
- GMP helper functions introduced for proof generation are moved to `util/GmpUtils`. This allows to reuse them for Mersenne cofactor testing
- `split` function is moved to `util/StringUtils`, as it is useful in both `WorktodoParser` and `CliParser`


