### PR TITLE
Proof generation on the GPU

### DIFF
--- a/include/core/App.hpp
+++ b/include/core/App.hpp
@@ -44,33 +44,6 @@ public:
     int run();
     void tuneIterforce();
     double measureIps(uint64_t testIterforce, uint64_t testIters);
-    void gpuSquareInPlace(
-                                    cl_mem A,
-                                    math::Carry& carry,
-                                    size_t limbBytes,
-                                    cl_mem blockCarryBuf);
-    void gpuMulInPlace(
-                                 cl_mem A, cl_mem B,
-                                 math::Carry& carry,
-                                 size_t limbBytes,
-                                 cl_mem blockCarryBuf);
-    void gpuMulInPlace2(
-                                 cl_mem A, cl_mem B,
-                                 math::Carry& carry,
-                                 size_t limbBytes,
-                                 cl_mem blockCarryBuf);
-    void gpuMulInPlace3(
-                                 cl_mem A, cl_mem B,
-                                 math::Carry& carry,
-                                 size_t limbBytes,
-                                 cl_mem blockCarryBuf);
-    void gpuMulInPlace5(
-                                 cl_mem A, cl_mem B,
-                                 math::Carry& carry,
-                                 size_t limbBytes,
-                                 cl_mem blockCarryBuf);
-    void subOneGPU(cl_mem buf);
-    void gpuCopy(cl_command_queue q, cl_mem src, cl_mem dst, size_t bytes);
 
 private:
   int    argc_;

--- a/include/core/ProofManager.hpp
+++ b/include/core/ProofManager.hpp
@@ -13,6 +13,16 @@
 #include <filesystem>
 #include "core/ProofSet.hpp"
 
+// Forward declarations
+namespace opencl {
+    class NttEngine;
+    class Context;
+}
+
+namespace math {
+    class Carry;
+}
+
 namespace core {
 
 class ProofManager {
@@ -21,7 +31,7 @@ public:
                  cl_command_queue queue, uint32_t n,
                  const std::vector<int>& digitWidth);
     void checkpoint(cl_mem buf, uint32_t iter);    
-    std::filesystem::path proof() const;
+    std::filesystem::path proof(const opencl::Context& ctx, opencl::NttEngine& ntt, math::Carry& carry) const;
 
 private:
     ProofSet           proofSet_;

--- a/include/io/JsonBuilder.hpp
+++ b/include/io/JsonBuilder.hpp
@@ -52,6 +52,11 @@ public:
         const std::vector<uint64_t>& x,
         const std::vector<int>& digit_width,
         uint32_t E);
+    
+    static std::vector<uint64_t> expandBits(
+        const std::vector<uint32_t>& compactWords,
+        const std::vector<int>& digit_width,
+        uint32_t E);
 };
 
 } // namespace io

--- a/include/opencl/NttEngine.hpp
+++ b/include/opencl/NttEngine.hpp
@@ -14,6 +14,8 @@
 #include "opencl/Kernels.hpp"
 #include "opencl/NttPipeline.hpp"
 
+namespace math { class Carry; }
+
 namespace opencl {
 
 class NttEngine {
@@ -28,6 +30,14 @@ public:
     int forward_simple(cl_mem buf_x, uint64_t iter);
     int inverse_simple(cl_mem buf_x, uint64_t iter);
     int pointwiseMul(cl_mem a, cl_mem b);
+    
+    void mulInPlace(cl_mem A, cl_mem B, math::Carry& carry, size_t limbBytes);
+    void mulInPlace2(cl_mem A, cl_mem B, math::Carry& carry, size_t limbBytes);
+    void mulInPlace3(cl_mem A, cl_mem B, math::Carry& carry, size_t limbBytes);
+    void mulInPlace5(cl_mem A, cl_mem B, math::Carry& carry, size_t limbBytes);
+    void squareInPlace(cl_mem A, math::Carry& carry, size_t limbBytes);
+    void copy(cl_mem src, cl_mem dst, size_t bytes);
+    void subOne(cl_mem buf);
 
 private:
     size_t ls0_val_, ls2_val_, ls3_val_, ls5_val_;

--- a/include/opencl/NttEngine.hpp
+++ b/include/opencl/NttEngine.hpp
@@ -36,6 +36,7 @@ public:
     void mulInPlace3(cl_mem A, cl_mem B, math::Carry& carry, size_t limbBytes);
     void mulInPlace5(cl_mem A, cl_mem B, math::Carry& carry, size_t limbBytes);
     void squareInPlace(cl_mem A, math::Carry& carry, size_t limbBytes);
+    void powInPlace(cl_mem result, cl_mem base, uint64_t exp, math::Carry& carry, size_t limbBytes);
     void copy(cl_mem src, cl_mem dst, size_t bytes);
     void subOne(cl_mem buf);
 

--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -1074,7 +1074,7 @@ int App::runPrpOrLl() {
     if (options.proof) {
         try {
             std::cout << "\nGenerating PRP proof file..." << std::endl;
-            auto proofFilePath = proofManager.proof();
+            auto proofFilePath = proofManager.proof(context, *nttEngine, carry);
             options.proofFile = proofFilePath.string();  // Set proof file path
             std::cout << "Proof file saved: " << proofFilePath << std::endl;
         } catch (const std::exception& e) {

--- a/src/io/JsonBuilder.cpp
+++ b/src/io/JsonBuilder.cpp
@@ -118,6 +118,40 @@ std::vector<uint32_t> JsonBuilder::compactBits(
     return out;
 }
 
+std::vector<uint64_t> JsonBuilder::expandBits(
+    const std::vector<uint32_t>& compactWords,
+    const std::vector<int>&      digit_width,
+    uint32_t                     E
+) {
+    uint32_t digitCount = static_cast<uint32_t>(digit_width.size());
+    std::vector<uint64_t> out(digitCount, 0);
+    
+    // Bit buffer for extracting variable-width values
+    uint64_t bitBuffer = 0;
+    int      availableBits = 0;
+    uint32_t wordIndex = 0;
+    
+    for (uint32_t p = 0; p < digitCount; ++p) {
+        int w = digit_width[p];
+        
+        // Fill buffer if we don't have enough bits
+        while (availableBits < w && wordIndex < compactWords.size()) {
+            bitBuffer |= (uint64_t(compactWords[wordIndex]) << availableBits);
+            availableBits += 32;
+            wordIndex++;
+        }
+        
+        // Extract w bits as the value
+        uint64_t mask = (1ULL << w) - 1;
+        out[p] = bitBuffer & mask;
+        
+        // Remove extracted bits from buffer
+        bitBuffer >>= w;
+        availableBits -= w;
+    }
+    
+    return out;
+}
 
 static std::string fileMD5(const std::string& filePath) {
     namespace fs = std::filesystem;


### PR DESCRIPTION
This PR is an attempt to implement proof generation using existing code for computations on the GPU.

Precisely, this PR contains the following changes:
- I added the `expandBits` function to `JsonBuilder` - the inverse of `compactBits`
- functions used for common operations on the GPU (e.g. `squareInPlace` and `mulInPlace*`) are moved from `App` to `NttEngine` to allow reuse of them in `ProofSet`
- `squareInPlace` function had some code commented out and didn't work as is. I updated this function - now it's implementation is similar to `mulInPlace5`
- I added the `powInPlace` function. It's implementation is similar to `mersennePowMod` used previously, but it uses  `squareInPlace` and `mulInPlace5` to perform computation on the GPU
- `ProofSet::computeProof` is updated to use these GPU operations instead of GMP

The proof generation time on RTX 3090 for M3021377 is just 3 seconds now. The proof is successfully verified with PRPLL.
This PR can benefit from thorough code review and more extensive testing though.

