### PR TITLE
Update `computeResult` function to use `vectToMpz`

### DIFF
--- a/include/core/App.hpp
+++ b/include/core/App.hpp
@@ -67,9 +67,6 @@ private:
 };
 
 mpz_class buildE(uint64_t B1);
-void vectToMpz(mpz_t out,
-                const std::vector<uint64_t>& v,
-                const std::vector<int>& widths);
 void readGpuBufferWithProgress(cl_command_queue q,
                                cl_mem            deviceBuf,
                                void*             hostPtr,

--- a/include/math/Cofactor.hpp
+++ b/include/math/Cofactor.hpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <string>
 #include <cstdint>
+#include <gmpxx.h>
 
 namespace math {
 
@@ -17,7 +18,7 @@ public:
     // residue == base^(KF-1) (mod N)
     static bool isCofactorPRP(uint32_t exponent,
                               const std::vector<std::string>& factors,
-                              const std::vector<uint32_t>& finalResidue,
+                              const mpz_class& finalResidue,
                               uint32_t base = 3);
 
 };

--- a/include/util/GmpUtils.hpp
+++ b/include/util/GmpUtils.hpp
@@ -2,11 +2,16 @@
 #include <cstdint>
 #include <vector>
 #include <gmpxx.h>
+#include <gmp.h>
 
 // GMP-based modular arithmetic helpers
 namespace util {
     mpz_class convertToGMP(const std::vector<uint32_t>& words);
     std::vector<uint32_t> convertFromGMP(const mpz_class& gmp_val);
+    mpz_class vectToMpz(const std::vector<uint64_t>& v,
+                        const std::vector<int>& widths,
+                        const mpz_class& Mp);
+
     mpz_class mersenneReduce(const mpz_class& x, uint32_t E);
     mpz_class mersennePowMod(const mpz_class& base, uint64_t exp, uint32_t E);
 }

--- a/src/math/Cofactor.cpp
+++ b/src/math/Cofactor.cpp
@@ -36,10 +36,9 @@ bool Cofactor::validateFactors(uint32_t exponent, const std::vector<std::string>
 // residue == base^(KF-1) (mod N)
 bool Cofactor::isCofactorPRP(uint32_t exponent,
                              const std::vector<std::string>& factors,
-                             const std::vector<uint32_t>& finalResidue,
+                             const mpz_class& finalResidue,
                              uint32_t base) {  
   try {
-    mpz_class finalRes = util::convertToGMP(finalResidue);
     mpz_class baseGmp{base};
     
     mpz_class knownFactorsProduct{1};
@@ -55,7 +54,7 @@ bool Cofactor::isCofactorPRP(uint32_t exponent,
     mpz_class expected;
     mpz_powm(expected.get_mpz_t(), baseGmp.get_mpz_t(), kfMinus1.get_mpz_t(), cofactor.get_mpz_t());
     
-    mpz_class actual = finalRes % cofactor;
+    mpz_class actual = finalResidue % cofactor;
     bool isPrime = (actual == expected);
     
     return isPrime;


### PR DESCRIPTION
This PR contains some refactoring:
- the code is changed to use `mpz_class` form GMP instead of custom `MpzWrapper` or direct operations on `mpz_t`
- `vectToMpz` function is moved to `GmpUtils`
- `JsonBuilder::computeResult` function is updated to use `vectToMpz` to convert the data from GPU to GMP format directly, instead of running `compactBits` followed up by `convertToGMP`