### PR TITLE
Allow the user to set proof power manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ You should now have `prmers.exe` ready to run!
 - `-factors <factor1,factor2,...>`: Specify known factors to run PRP test on the Mersenne cofactor
 - `-t <backup_interval>`: Specify the backup interval in seconds (default: 60)
 - `-f <path>`: Specify the directory path for saving/loading backup files (default: current directory)
+- `-proof <level>`: Set proof power between 1 and 12 or 0 to disable proof generation (default: optimal proof power selected automatically)
 - `-enqueue_max <value>`: Manually set the maximum number of enqueued kernels before `clFinish` is called (default: autodetect)
 - `--noask`: Automatically submit results to PrimeNet without prompting
 - `-user <username>`: PrimeNet account username to use for automatic result submission

--- a/include/io/CliParser.hpp
+++ b/include/io/CliParser.hpp
@@ -42,7 +42,8 @@ struct CliOptions {
     std::string kernel_path;
     std::string output_path;
     std::string build_options = "";
-    int proofPower = 1;
+    uint32_t proofPower = 1;
+    bool manual_proofPower = false; // Track if proof power is set manually
     std::string proofFile = "";
     int portCode = 8;
     std::string osName = "Linux";

--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -329,7 +329,11 @@ App::App(int argc, char** argv)
     )
   , proofManager(
         options.exponent,
-        options.proof ? ProofSet::bestPower(options.exponent) : 0,
+        [this]() -> uint32_t {
+            if (!this->options.proof) return 0;
+            if (this->options.manual_proofPower) return this->options.proofPower;
+            return ProofSet::bestPower(this->options.exponent);
+        }(),
         context.getQueue(),
         precompute.getN(),
         precompute.getDigitWidth(),
@@ -458,7 +462,7 @@ int App::runPrpOrLl() {
 
     // Display proof disk usage estimate at start of computation
     if (options.proof) {
-        int proofPower = ProofSet::bestPower(options.exponent);
+        uint32_t proofPower = options.manual_proofPower ? options.proofPower : ProofSet::bestPower(options.exponent);
         options.proofPower = proofPower;
         double diskUsageGB = ProofSet::diskUsageGB(options.exponent, proofPower);
         std::cout << "Proof of power " << proofPower << " requires about "

--- a/src/io/CliParser.cpp
+++ b/src/io/CliParser.cpp
@@ -67,7 +67,7 @@ void printUsage(const char* progName) {
     std::cout << "  -computer <name>     : (Optional) PrimeNet computer name to auto-fill the result submission" << std::endl;
     std::cout << "  -worktodo <path>     : (Optional) Load exponent from specified worktodo.txt (default: ./worktodo.txt)" << std::endl;
     std::cout << "  -config <path>       : (Optional) Load config file from specified path" << std::endl;
-    std::cout << "  -proof               : (Optional) Disable proof generation (by default a proof is created if PRP test passes)" << std::endl;
+    std::cout << "  -proof <level>       : (Optional) Set proof power between 1 and 12 or 0 to disable proof generation (default: optimal proof power selected automatically)" << std::endl;
     std::cout << "  -erroriter <iter>    : (Optional) injects an error at iteration <iter> to test Gerbicz-Li error detection mechanism." << std::endl;
     std::cout << "  -iterforce <iter>    : (Optional) forces a GPU queue synchronization (clFinish) every <iter> iterations to improve stability or allow interruption checks." << std::endl;
     std::cout << "  -iterforce2 <iter>   : (Optional) forces a GPU queue synchronization in P-1 stage 2 (clFinish) every <iter> iterations to improve stability or allow interruption checks." << std::endl;
@@ -146,8 +146,17 @@ CliOptions CliParser::parse(int argc, char** argv ) {
         else if (std::strcmp(argv[i], "-throttle_low") == 0) {
             opts.cl_queue_throttle_active = true;
         }
-        else if (std::strcmp(argv[i], "-proof") == 0) {
-            opts.proof = false;
+        else if (std::strcmp(argv[i], "-proof") == 0 && i + 1 < argc) {
+            int level = std::atoi(argv[++i]);
+            if (level == 0) {
+                opts.proof = false;
+            } else if (1 <= level && level <= 12) {
+                opts.proofPower = level;
+                opts.manual_proofPower = true;
+            } else {
+                std::cerr << "Error: -proof level must be between 0 and 12. Given: " << level << std::endl;
+                std::exit(EXIT_FAILURE);
+            }
         }
         else if (std::strcmp(argv[i], "-c") == 0 && i + 1 < argc) {
             opts.localCarryPropagationDepth = std::atoi(argv[++i]);


### PR DESCRIPTION
This PR contains a refactoring of the `-proof` option:
- `-proof` option now accepts an integer - this option allows to set the proof power manually
- setting `-proof` to `0` can be used to disable proof generation