### PR TITLE
Enable proof generation for even exponents

### DIFF
--- a/src/io/CliParser.cpp
+++ b/src/io/CliParser.cpp
@@ -279,9 +279,6 @@ CliOptions CliParser::parse(int argc, char** argv ) {
         std::cerr << "Error: No exponent provided.\n";
         std::exit(EXIT_FAILURE);
     }*/
-    if (opts.exponent % 2 == 0) {
-        opts.proof = false;
-    }
     constexpr uint64_t MAX_EXPONENT = 5650242869UL;
     if (opts.exponent > MAX_EXPONENT) {
         std::cerr << "Error: Exponent must be <= " << MAX_EXPONENT


### PR DESCRIPTION
Right now proof generation is disabled for even exponents in PrMers. It is disabled in `CliParser`, which appears to be introducing a bug when the exponent is not provided on the command line but is instead read from the `worktodo.txt` file. In such case `exponent` field in `CliOptions` is not updated with the tested exponent, and the check for evenness is performed on the default value of `exponent` field, which is `0`, and `0` is indeed even. This leads to the unexpected behavior that proof generation is disabled for all exponents read from `worktodo.txt`.

In this PR I propose to simply remove this check for evenness. It looks that proof generation is actually working fine for even exponents. I tested a few examples and the program produces correct proof file verifiable by PRPLL.