### PR TITLE
Print PrMers version in JSON results

### DIFF
--- a/include/core/Version.hpp
+++ b/include/core/Version.hpp
@@ -1,0 +1,10 @@
+#ifndef VERSION_HPP
+#define VERSION_HPP
+
+#include <string>
+
+namespace core {
+    const std::string PRMERS_VERSION = "4.8.05-alpha";
+} // namespace core
+
+#endif // VERSION_HPP

--- a/src/io/CliParser.cpp
+++ b/src/io/CliParser.cpp
@@ -28,6 +28,7 @@
 #include "util/PathUtils.hpp"
 #include <filesystem>
 #include "opencl/Context.hpp"
+#include "core/Version.hpp"
 
 // Forward-declare the usage function (defined elsewhere, e.g. in your main host file)
 extern void printUsage(const char* progName);
@@ -100,7 +101,7 @@ CliOptions CliParser::parse(int argc, char** argv ) {
         || std::strcmp(argv[i], "--version") == 0
         || std::strcmp(argv[i], "-version") == 0)
         {
-            std::cout << "prmers Release v4.8.05-alpha\n";
+            std::cout << "prmers Release v" << core::PRMERS_VERSION << "\n";
             std::exit(EXIT_SUCCESS);
         }
     }

--- a/src/io/JsonBuilder.cpp
+++ b/src/io/JsonBuilder.cpp
@@ -23,6 +23,7 @@
 #include "io/CliParser.hpp"          // for CliOptions
 #include "math/Cofactor.hpp"
 #include "util/GmpUtils.hpp"
+#include "core/Version.hpp"
 #ifndef CL_TARGET_OPENCL_VERSION
 #define CL_TARGET_OPENCL_VERSION 300
 #endif
@@ -398,7 +399,7 @@ std::string JsonBuilder::generate(const CliOptions& opts,
         opts.proof ? 64 : 0,
         opts.proof ? fileMD5(opts.proofFile) : "",
         "prmers",                  // programName
-        "0.1.0",                    // programVersion
+        core::PRMERS_VERSION,      // programVersion
         opts.portCode,             // portCode
         opts.osName,               // osName
         opts.osVersion,            // osVersion


### PR DESCRIPTION
The changes in this PR:
- move version constant to `Version.hpp`
- print actual PrMers version in JSON results instead of 0.1.0 placeholder