### PR TITLE
Write known factors to proof header

### DIFF
--- a/src/core/ProofSet.cpp
+++ b/src/core/ProofSet.cpp
@@ -327,7 +327,7 @@ Proof ProofSet::computeProof(const GpuContext& gpu) const {
   double elapsed = timer.elapsed();
   std::cout << "Proof generated in " << std::fixed << std::setprecision(2) << elapsed << " seconds." << std::endl;
   
-  return Proof{E, std::move(B), std::move(middles)};
+  return Proof{E, std::move(B), std::move(middles), knownFactors};
 }
 
 


### PR DESCRIPTION
I noticed that current version of PrMers does not write known factors to proof file header. It looks like this was overlooked during the merge of PRs #7 and #8. This PR will fix it.
