### PR TITLE
Fix displayed device bug in `-bench`: enumerate only GPU devices

### DIFF
--- a/src/core/App.cpp
+++ b/src/core/App.cpp
@@ -2319,14 +2319,15 @@ int App::runGpuBenchmarkMarin() {
     std::string fp64 = "Unknown";
     #ifdef CL_VERSION_1_0
     {
+        // Enumerate only GPU devices
         cl_uint np = 0; clGetPlatformIDs(0, nullptr, &np);
         std::vector<cl_platform_id> plats(np); if (np) clGetPlatformIDs(np, plats.data(), nullptr);
         std::vector<cl_device_id> devs;
         for (auto pid : plats) {
-            cl_uint nd = 0; clGetDeviceIDs(pid, CL_DEVICE_TYPE_ALL, 0, nullptr, &nd);
+            cl_uint nd = 0; clGetDeviceIDs(pid, CL_DEVICE_TYPE_GPU, 0, nullptr, &nd);
             if (!nd) continue;
             size_t old = devs.size(); devs.resize(old + nd);
-            clGetDeviceIDs(pid, CL_DEVICE_TYPE_ALL, nd, devs.data() + old, nullptr);
+            clGetDeviceIDs(pid, CL_DEVICE_TYPE_GPU, nd, devs.data() + old, nullptr);
         }
         size_t idx = (size_t)options.device_id;
         if (!devs.empty() && idx < devs.size()) {


### PR DESCRIPTION
On my computer I have these OpenCL devices (output of `clinfo -l`):

```
Platform #0: Intel(R) OpenCL
 `-- Device #0: Intel(R) Core(TM) i9-9900K CPU @ 3.60GHz
Platform #1: NVIDIA CUDA
 +-- Device #0: NVIDIA GeForce RTX 3090
 +-- Device #1: NVIDIA TITAN V
 `-- Device #2: NVIDIA TITAN V
```

When I run PrMers with `-bench` I noticed that it displays that I use the i9-9900k CPU, even though I can see using `nvtop` that the program is using the RTX 3090 GPU. I think that the reason for this is the difference in enumeration used for `-bench` and for printing in `-help` / selection with `-d`. In particular, for the latter only devices of GPU type are enumerated. With this PR I propose to also enumerate only GPU devices in `-bench`. This fixes the bug on my system.